### PR TITLE
Simplify ipstack get_details method and add Jira integration details method

### DIFF
--- a/autobotAI_integrations/integrations/ipstack/__init__.py
+++ b/autobotAI_integrations/integrations/ipstack/__init__.py
@@ -71,8 +71,7 @@ class IPStackService(BaseService):
             "clients": [],
             "supported_executor": "ecs",
             "compliance_supported": False,
-            "supported_interfaces": cls.supported_connection_interfaces(),
-            "preview": True
+            "supported_interfaces": cls.supported_connection_interfaces()
         }
 
     @staticmethod

--- a/autobotAI_integrations/integrations/jira/__init__.py
+++ b/autobotAI_integrations/integrations/jira/__init__.py
@@ -57,6 +57,24 @@ class JiraService(BaseService):
         except BaseException as e:
             return {"success": False, "error": str(e.text)}
 
+    def get_integration_specific_details(self) -> dict:
+        try:
+            jira_cloud_options = {"server": self.integration.base_url}
+            jira_cloud = JIRA(
+                options=jira_cloud_options,
+                basic_auth=(
+                    self.integration.username,
+                    self.integration.token or self.integration.personal_access_token,
+                ),
+            )
+            return {
+                "integration_id": self.integration.accountId,
+                "projects": [project.key for project in jira_cloud.projects()],
+                "issue_types": [issue.name for issue in jira_cloud.issue_types()],
+            }
+        except Exception as e:
+            return {"error": "Details can not be fetched"}
+
     @staticmethod
     def get_forms():
         return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve specific integration details for Jira, enhancing integration status visibility.
- **Bug Fixes**
	- Removed the `"preview"` key from the `get_details` method in the IPStack integration, simplifying the returned data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->