### PR TITLE
Refactor integration fields to use Optional for improved type safety …

### DIFF
--- a/autobotAI_integrations/integrations/bitbucket_cloud/__init__.py
+++ b/autobotAI_integrations/integrations/bitbucket_cloud/__init__.py
@@ -22,8 +22,8 @@ from autobotAI_integrations.models import IntegrationCategory
 
 class BitBucketCloudIntegration(BaseSchema):
     base_url: str = Field(default="https://api.bitbucket.org/2.0")
-    username: str = Field(default=None, exclude=True)
-    password: str = Field(default=None, exclude=True)
+    username: Optional[str] = Field(default=None, exclude=True)
+    password: Optional[str] = Field(default=None, exclude=True)
 
     name: Optional[str] = "BitBucket Cloud"
     category: Optional[str] = IntegrationCategory.CODE_REPOSITORY.value

--- a/autobotAI_integrations/integrations/elasticsearch/__init__.py
+++ b/autobotAI_integrations/integrations/elasticsearch/__init__.py
@@ -16,7 +16,7 @@ from autobotAI_integrations.payload_schema import PayloadTask
 
 
 class ElasticsearchIntegration(BaseSchema):
-    base_url: str = Field(default=None, description="base url", exclude=True)
+    base_url: Optional[str] = Field(default=None, description="base url", exclude=True)
     token: Optional[str] = Field(default=None, description="token", exclude=True)
 
     name: Optional[str] = "Elasticsearch"

--- a/autobotAI_integrations/integrations/gitguardian/__init__.py
+++ b/autobotAI_integrations/integrations/gitguardian/__init__.py
@@ -12,7 +12,7 @@ from autobotAI_integrations.models import IntegrationCategory
 
 class GitGuardianIntegration(BaseSchema):
     base_url: str = "https://api.gitguardian.com/v1/"
-    token: str = Field(default=None, exclude=True)
+    token: Optional[str] = Field(default=None, exclude=True)
 
     name: Optional[str] = "GitGuardian"
     category: Optional[str] = IntegrationCategory.SECURITY_TOOLS.value

--- a/autobotAI_integrations/integrations/github/__init__.py
+++ b/autobotAI_integrations/integrations/github/__init__.py
@@ -13,7 +13,7 @@ from autobotAI_integrations.models import IntegrationCategory
 
 class GithubIntegration(BaseSchema):
     base_url: str =  Field(default="https://api.github.com")# If enterprise version of github
-    token: str = Field(default=None, exclude=True)
+    token: Optional[str] = Field(default=None, exclude=True)
 
     name: Optional[str] = "GitHub"
     category: Optional[str] = IntegrationCategory.CODE_REPOSITORY.value

--- a/autobotAI_integrations/integrations/gitlab/__init__.py
+++ b/autobotAI_integrations/integrations/gitlab/__init__.py
@@ -20,7 +20,7 @@ from autobotAI_integrations.models import IntegrationCategory
 
 class GitlabIntegration(BaseSchema):
     base_url: str = Field(default="https://gitlab.com/", exclude=True)
-    token: str = Field(default=None, exclude=True)
+    token: Optional[str] = Field(default=None, exclude=True)
 
     name: Optional[str] = "GitLab"
     category: Optional[str] = IntegrationCategory.CODE_REPOSITORY.value

--- a/autobotAI_integrations/integrations/jira/__init__.py
+++ b/autobotAI_integrations/integrations/jira/__init__.py
@@ -22,8 +22,8 @@ from autobotAI_integrations.models import IntegrationCategory
 class JiraIntegration(BaseSchema):
     base_url: str = Field(default="https://jira.atlassian.com")
     username: str = Field(default=None, exclude=True)
-    token: str = Field(default=None, exclude=True)
-    personal_access_token: str = Field(default=None, exclude=True)
+    token: Optional[str] = Field(default=None, exclude=True)
+    personal_access_token: Optional[str] = Field(default=None, exclude=True)
 
     category: Optional[str] = IntegrationCategory.NOTIFICATIONS_AND_COMMUNICATIONS.value
     description: Optional[str] = (

--- a/autobotAI_integrations/integrations/openai/__init__.py
+++ b/autobotAI_integrations/integrations/openai/__init__.py
@@ -21,7 +21,7 @@ from autobotAI_integrations.utils.logging_config import logger
 
 
 class OpenAIIntegration(BaseSchema):
-    api_key: str = Field(default=None, exclude=True)
+    api_key: Optional[str] = Field(default=None, exclude=True)
 
     name: Optional[str] = "OpenAI"
     category: Optional[str] = IntegrationCategory.AI.value

--- a/autobotAI_integrations/integrations/python_http_requests/__init__.py
+++ b/autobotAI_integrations/integrations/python_http_requests/__init__.py
@@ -19,7 +19,7 @@ from .http_requests_client import HTTPRequestClient
 
 
 class PythonHTTPRequestIntegration(BaseSchema):
-    api_url: str = Field(default=None, exclude=True)
+    api_url: Optional[str] = Field(default=None, exclude=True)
     headers_json: Dict[str, str] = Field(default=dict(), exclude=True)
     healthcheck_get_api_path: Optional[str] = Field(default=None, exclude=True)
     ignore_ssl: bool = False


### PR DESCRIPTION
…in BitBucket, Elasticsearch, GitGuardian, GitHub, GitLab, Jira, OpenAI, and Python HTTP Requests integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated several integration settings to explicitly allow certain fields (such as tokens, usernames, passwords, API keys, and URLs) to be left empty or unset, improving clarity and flexibility when configuring integrations. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->