### PR TITLE
Update header key from API-KEY to Auth-Key for MalwareBazar integration

### DIFF
--- a/autobotAI_integrations/integrations/malware_bazar/__init__.py
+++ b/autobotAI_integrations/integrations/malware_bazar/__init__.py
@@ -41,7 +41,7 @@ class MalwareBazarService(BaseService):
         try:
             response = requests.post(
                 self.integration.base_url,
-                headers={"API-KEY": self.integration.api_key},
+                headers={"Auth-Key": self.integration.api_key},
                 data={"query": "get_recent", "selector": "time"},
                 timeout=10,
             )
@@ -69,7 +69,7 @@ class MalwareBazarService(BaseService):
                 {
                     "name": "api_key",
                     "type": "text/password",
-                    "label": "API Key",
+                    "label": "Auth Key",
                     "placeholder": "Enter the MalwareBazar API Key",
                     "required": True,
                 }
@@ -96,7 +96,7 @@ class MalwareBazarService(BaseService):
         return RestAPICreds(
             base_url=self.integration.base_url,
             headers={
-                "API-KEY": self.integration.api_key,
+                "Auth-Key": self.integration.api_key,
                 "Content-Type": None,
             },
             request_body_type=RestAPIRequestBodyType.FORM_DATA.value,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the MalwareBazar integration to use the “Auth-Key” header for authentication, ensuring requests succeed.
  * Updated the settings form label to “Auth Key” for consistency with the service.
  * Improves compatibility without affecting existing workflows.

* **Chores**
  * Aligned credential handling with the updated authentication header naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->