### PR TITLE
feat(aws): opt-in RefreshableCredentials for python_sdk tasks

### DIFF
--- a/autobotAI_integrations/integrations/aws/__init__.py
+++ b/autobotAI_integrations/integrations/aws/__init__.py
@@ -13,6 +13,10 @@ from autobotAI_integrations import BaseService, list_of_unique_elements, Payload
 from autobotAI_integrations.models import *
 from autobotAI_integrations.utils.boto3_helper import Boto3Helper
 from autobotAI_integrations.utils.logging_config import logger
+from autobotAI_integrations.utils.refreshable_creds import (
+    build_refreshable_aws_session,
+    current_aws_creds_resolver,
+)
 
 
 class Forms:
@@ -197,13 +201,39 @@ class AWSService(BaseService):
         regional_clients = pydash.filter_(client_definitions, lambda x: x.is_regional is True)
         creds = {
             "aws_access_key_id": payload_task.creds.envs["AWS_ACCESS_KEY_ID"],
-            "aws_secret_access_key": payload_task.creds.envs["AWS_SECRET_ACCESS_KEY"],            
+            "aws_secret_access_key": payload_task.creds.envs["AWS_SECRET_ACCESS_KEY"],
         }
         if payload_task.creds.envs.get("AWS_SESSION_TOKEN"):
             creds["aws_session_token"] = payload_task.creds.envs.get("AWS_SESSION_TOKEN")
+
+        # Long-running agent sessions (autobotAI deep agent) set a
+        # contextvar holding a refresh callable.  When present, build boto3
+        # clients with RefreshableCredentials so credentials auto-refresh
+        # per AWS API call — no ExpiredToken mid-call even if a single
+        # python_sdk task runs longer than the STS TTL.  Lambda/CLI callers
+        # leave the contextvar unset and get the existing static-creds path.
+        resolver = current_aws_creds_resolver.get()
+        use_refreshable = resolver is not None
+
+        def _global_client(name: str):
+            if use_refreshable:
+                session = build_refreshable_aws_session(
+                    resolver, payload_task.task_id, region_name=None
+                )
+                return session.client(name)
+            return boto3.client(name, **creds)
+
+        def _regional_client(name: str, region: str):
+            if use_refreshable:
+                session = build_refreshable_aws_session(
+                    resolver, payload_task.task_id, region_name=region
+                )
+                return session.client(name, region_name=region)
+            return boto3.client(name, region_name=region, **creds)
+
         if global_clients:
             for client in global_clients:
-                built_clients["global"][client.name] = boto3.client(client.name, **creds)
+                built_clients["global"][client.name] = _global_client(client.name)
         if regional_clients:
             active_regions = self.integration.activeRegions
             if not active_regions:
@@ -213,8 +243,9 @@ class AWSService(BaseService):
                 built_clients["regional"].setdefault(region, {})
                 for client in regional_clients:
                     try:
-                        built_clients["regional"][region][client.name] = boto3.client(client.name, region_name=region,
-                                                                                      **creds)
+                        built_clients["regional"][region][client.name] = _regional_client(
+                            client.name, region
+                        )
                     except ImportError:
                         logger.exception(f"Failed create client for {client['name']}")
         combinations = []

--- a/autobotAI_integrations/integrations/aws/__init__.py
+++ b/autobotAI_integrations/integrations/aws/__init__.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Type, Union
+from typing import Any, Dict, Type, Union
 from enum import Enum
 
 import uuid
@@ -215,20 +215,32 @@ class AWSService(BaseService):
         resolver = current_aws_creds_resolver.get()
         use_refreshable = resolver is not None
 
+        # Memoize one refreshable session per scope so all clients in the
+        # same scope share one credentials object (and one refresh cycle).
+        # Without this, every client would have its own RefreshableCredentials
+        # and would re-invoke the resolver independently — wasteful and a
+        # source of duplicate cred-refresh traffic.
+        _global_session: list = []  # mutable cell for closure
+        _regional_sessions: Dict[str, Any] = {}
+
         def _global_client(name: str):
             if use_refreshable:
-                session = build_refreshable_aws_session(
-                    resolver, payload_task.task_id, region_name=None
-                )
-                return session.client(name)
+                if not _global_session:
+                    _global_session.append(
+                        build_refreshable_aws_session(
+                            resolver, payload_task.task_id, region_name=None
+                        )
+                    )
+                return _global_session[0].client(name)
             return boto3.client(name, **creds)
 
         def _regional_client(name: str, region: str):
             if use_refreshable:
-                session = build_refreshable_aws_session(
-                    resolver, payload_task.task_id, region_name=region
-                )
-                return session.client(name, region_name=region)
+                if region not in _regional_sessions:
+                    _regional_sessions[region] = build_refreshable_aws_session(
+                        resolver, payload_task.task_id, region_name=region
+                    )
+                return _regional_sessions[region].client(name, region_name=region)
             return boto3.client(name, region_name=region, **creds)
 
         if global_clients:

--- a/autobotAI_integrations/utils/refreshable_creds.py
+++ b/autobotAI_integrations/utils/refreshable_creds.py
@@ -46,8 +46,11 @@ _DEFAULT_TTL_SECONDS = 3500
 
 # Callable signature: takes the task_id (so a single resolver can serve
 # multiple tasks in the same process) and returns the botocore-shaped creds.
-# When the resolver has no creds for the given task_id, returning ``None``
-# tells the caller to fall through to the static-creds path.
+# The caller (``AWSService.build_python_exec_combinations_hook``) decides
+# whether to invoke this path at all by checking the contextvar — once
+# ``build_refreshable_aws_session`` is called, the resolver MUST return
+# valid creds for the requested task_id on every call (including the
+# initial one), or a ``ValueError`` will be raised.
 AWSCredsResolver = Callable[[Optional[str]], Optional[Dict[str, Any]]]
 
 current_aws_creds_resolver: "contextvars.ContextVar[Optional[AWSCredsResolver]]" = (

--- a/autobotAI_integrations/utils/refreshable_creds.py
+++ b/autobotAI_integrations/utils/refreshable_creds.py
@@ -1,0 +1,109 @@
+"""Optional refreshable credentials for AWS python-SDK actions.
+
+By default, ``AWSService.build_python_exec_combinations_hook`` builds boto3
+clients with static credentials extracted from ``payload_task.creds.envs``.
+Those credentials are STS-issued and expire after ~1 hour (role-chaining
+cap), which is fine for short Lambda invocations but causes
+``ExpiredTokenException`` mid-call in long-running agent sessions.
+
+This module offers an *opt-in* refreshable-credentials path:
+
+1. A caller (the autobotAI agent, in long-running mode) sets the contextvar
+   ``current_aws_creds_resolver`` to a callable that returns fresh AWS env
+   credentials on demand.
+2. The AWS service checks the contextvar inside the python-SDK hook.  When
+   set, it builds boto3 clients backed by ``botocore.RefreshableCredentials``
+   whose refresh callback invokes the resolver.  Botocore re-reads
+   credentials whenever the cached set is within ~15 minutes of expiry.
+3. When the contextvar is unset (Lambda mode, standalone CLI use, tests),
+   the existing static-credentials path is taken — fully backward
+   compatible.
+
+The resolver returns a dict shaped for botocore::
+
+    {
+        "access_key": "...",
+        "secret_key": "...",
+        "token": "...",          # optional
+        "expiry_time": "<ISO-8601>",
+    }
+"""
+
+from __future__ import annotations
+
+import contextvars
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+if TYPE_CHECKING:
+    import boto3
+
+# Default fallback TTL when the resolver returns no ``expiry_time``.  Real
+# STS sessions are 3600s; we use 3500s to leave a small margin between
+# server-side issuance and consumption here.
+_DEFAULT_TTL_SECONDS = 3500
+
+
+# Callable signature: takes the task_id (so a single resolver can serve
+# multiple tasks in the same process) and returns the botocore-shaped creds.
+# When the resolver has no creds for the given task_id, returning ``None``
+# tells the caller to fall through to the static-creds path.
+AWSCredsResolver = Callable[[Optional[str]], Optional[Dict[str, Any]]]
+
+current_aws_creds_resolver: "contextvars.ContextVar[Optional[AWSCredsResolver]]" = (
+    contextvars.ContextVar("current_aws_creds_resolver", default=None)
+)
+
+
+def build_refreshable_aws_session(
+    resolver: AWSCredsResolver,
+    task_id: Optional[str],
+    region_name: Optional[str] = None,
+) -> "boto3.Session":
+    """Return a boto3.Session whose credentials auto-refresh via *resolver*.
+
+    Botocore calls the refresh callback whenever the cached creds are within
+    ~15 minutes of expiry — so any client built from this session picks up
+    rotated STS creds transparently on the next AWS API call.
+    """
+    import boto3
+    from botocore.credentials import RefreshableCredentials
+    from botocore.session import get_session as get_botocore_session
+
+    def _refresh() -> Dict[str, Any]:
+        snapshot = resolver(task_id) or {}
+        # Ensure the shape botocore expects.  ``expiry_time`` is required —
+        # synthesize one from "now + default TTL" when the resolver doesn't
+        # provide it.
+        access_key = snapshot.get("access_key") or snapshot.get("AWS_ACCESS_KEY_ID")
+        secret_key = snapshot.get("secret_key") or snapshot.get("AWS_SECRET_ACCESS_KEY")
+        token = snapshot.get("token") or snapshot.get("AWS_SESSION_TOKEN")
+        expiry = snapshot.get("expiry_time")
+        if not expiry:
+            expiry = (
+                datetime.now(timezone.utc) + timedelta(seconds=_DEFAULT_TTL_SECONDS)
+            ).isoformat()
+        return {
+            "access_key": access_key,
+            "secret_key": secret_key,
+            "token": token,
+            "expiry_time": expiry,
+        }
+
+    initial = _refresh()
+    if not initial.get("access_key") or not initial.get("secret_key"):
+        raise ValueError(
+            "AWS creds resolver returned empty access/secret key on first call"
+        )
+
+    creds = RefreshableCredentials.create_from_metadata(
+        metadata=initial,
+        refresh_using=_refresh,
+        method="autobotai-task-rotation",
+    )
+
+    botocore_session = get_botocore_session()
+    botocore_session._credentials = creds
+    if region_name:
+        botocore_session.set_config_variable("region", region_name)
+    return boto3.Session(botocore_session=botocore_session)

--- a/tests/test_utills/test_refreshable_creds.py
+++ b/tests/test_utills/test_refreshable_creds.py
@@ -1,0 +1,117 @@
+"""Unit tests for the opt-in refreshable AWS credentials path.
+
+The integrations library normally builds boto3 clients with static
+credentials.  When the autobotAI agent runs a long session it sets a
+``contextvars.ContextVar`` holding a refresh callable; the AWS service
+checks that var and switches to ``botocore.RefreshableCredentials``.
+
+These tests cover the primitive only — the AWS service-side integration
+(``AWSService.build_python_exec_combinations_hook``) is exercised via
+the agent's smoke tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from autobotAI_integrations.utils.refreshable_creds import (
+    build_refreshable_aws_session,
+    current_aws_creds_resolver,
+)
+
+
+def _expiry(seconds_from_now: int) -> str:
+    return (
+        datetime.now(timezone.utc) + timedelta(seconds=seconds_from_now)
+    ).isoformat()
+
+
+class TestBuildRefreshableAWSSession:
+    def test_session_uses_resolver_credentials(self):
+        def resolver(task_id):
+            return {
+                "access_key": "AKIA-A",
+                "secret_key": "SEC-A",
+                "token": "TOK-A",
+                "expiry_time": _expiry(3500),
+            }
+
+        session = build_refreshable_aws_session(
+            resolver, task_id="t1", region_name="us-east-1"
+        )
+        frozen = session.get_credentials().get_frozen_credentials()
+        assert frozen.access_key == "AKIA-A"
+        assert frozen.secret_key == "SEC-A"
+        assert frozen.token == "TOK-A"
+
+    def test_refresh_callback_is_invoked_on_expiry(self):
+        state = {"generation": 0}
+
+        def resolver(task_id):
+            state["generation"] += 1
+            return {
+                "access_key": f"AKIA-{state['generation']}",
+                "secret_key": f"SEC-{state['generation']}",
+                "token": f"TOK-{state['generation']}",
+                "expiry_time": _expiry(3500),
+            }
+
+        session = build_refreshable_aws_session(resolver, task_id="t1")
+        creds_obj = session.get_credentials()
+
+        # First read pulls from initial metadata (generation=1).
+        first = creds_obj.get_frozen_credentials()
+        assert first.access_key == "AKIA-1"
+
+        # Force a refresh.
+        creds_obj._expiry_time = datetime.now(timezone.utc) - timedelta(
+            seconds=10
+        )
+        second = creds_obj.get_frozen_credentials()
+        assert second.access_key == "AKIA-2"
+
+    def test_resolver_accepts_env_var_shape(self):
+        """Some callers find it cleaner to return AWS_* env var keys; the
+        builder should normalise these too."""
+
+        def resolver(task_id):
+            return {
+                "AWS_ACCESS_KEY_ID": "AKIA",
+                "AWS_SECRET_ACCESS_KEY": "SEC",
+                "AWS_SESSION_TOKEN": "TOK",
+                "expiry_time": _expiry(3500),
+            }
+
+        session = build_refreshable_aws_session(resolver, task_id="t1")
+        frozen = session.get_credentials().get_frozen_credentials()
+        assert frozen.access_key == "AKIA"
+
+    def test_empty_creds_first_call_raises(self):
+        def resolver(task_id):
+            return None
+
+        with pytest.raises(ValueError):
+            build_refreshable_aws_session(resolver, task_id="t1")
+
+
+class TestContextVar:
+    def test_default_is_none(self):
+        # Each test runs in a fresh contextvar scope.
+        assert current_aws_creds_resolver.get() is None
+
+    def test_set_and_reset(self):
+        def resolver(task_id):
+            return {
+                "access_key": "x",
+                "secret_key": "y",
+                "expiry_time": _expiry(3500),
+            }
+
+        token = current_aws_creds_resolver.set(resolver)
+        try:
+            assert current_aws_creds_resolver.get() is resolver
+        finally:
+            current_aws_creds_resolver.reset(token)
+        assert current_aws_creds_resolver.get() is None


### PR DESCRIPTION
## Summary

Long-running agent sessions (≥1h) need AWS STS creds to refresh during multi-hour python_sdk tasks. Today `AWSService.build_python_exec_combinations_hook` builds boto3 clients with **static** creds from `payload_task.creds.envs`, so a task that outlives the ~1h STS TTL hits `ExpiredTokenException` mid-call.

This PR adds an **opt-in** refresh path that's fully backward-compatible with Lambda / CLI / direct callers:

- New util module `refreshable_creds.py` with:
  - `current_aws_creds_resolver` — a `contextvars.ContextVar` holding an optional `(task_id) -> creds dict` callable.
  - `build_refreshable_aws_session()` — wraps the resolver in `botocore.RefreshableCredentials` so any client built from the returned session auto-refreshes credentials per AWS API call.
- `AWSService.build_python_exec_combinations_hook` checks the contextvar:
  - **Set** (agent long-running mode): builds clients via the refreshable session — creds refresh transparently mid-call.
  - **Unset** (Lambda, CLI, tests): falls through to existing static-creds path — zero behavioral change.

## Companion PRs

- **autobotAI-agent**: [feat-refreshable-bedrock-creds](https://github.com/shunyeka-spl/autobotAI-agent/pull/new/feat-refreshable-bedrock-creds) — sets the contextvar from the agent's action_tools wrapper and runs the refresh loop.
- **autobotAI-core**: [feat-stamp-creds-expiry](https://github.com/shunyeka-spl/autobotAI-core/pull/new/feat-stamp-creds-expiry) — stamps `credentials_expires_at` on the `/refresh-payload` response so botocore's refresh window aligns with real STS expiry.

## Test plan

- [x] New unit tests in `tests/test_utills/test_refreshable_creds.py` (6 tests, all passing): callback returns current resolver state, refresh fires when expiry elapses, env-var-shape creds accepted, empty creds raise, contextvar default + set/reset semantics.
- [x] Full `tests/test_utills/` suite passes (17 tests).
- [ ] Manual: long-running agent session > 1h confirms in-task AWS calls succeed after STS rotation (requires deploy to dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS credentials now automatically refresh during long-running sessions, eliminating the need for manual credential rotation and improving agent session reliability for extended operations.

* **Tests**
  * Added comprehensive tests verifying refreshable AWS credential functionality, including resolver behavior, credential expiration handling, environment variable normalization, and context variable state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shunyeka-spl/autobotAI-integrations/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->