### PR TITLE
feat(deep-agent): add allow_user_interaction to DeepAgentPayload

### DIFF
--- a/autobotAI_integrations/deep_agent_schema.py
+++ b/autobotAI_integrations/deep_agent_schema.py
@@ -240,6 +240,15 @@ class DeepAgentPayload(Payload):
         True,
         description="True = autonomous execution, False = human-in-the-loop",
     )
+    # Distinct from `autonomous` (which gates approve-before-each-action on
+    # execute/write_file). This is the single switch for whether a human is in
+    # the loop at all: when True the agent gets the request_approval HITL tool
+    # and the chat thread accepts user messages; when False the run is headless
+    # — no HITL pause, and core stops the ECS task once the work completes.
+    allow_user_interaction: bool = Field(
+        True,
+        description="True = HITL tools + UI chat messages available; False = headless run, no human pause.",
+    )
     filesystem_enabled: bool = Field(
         True,
         description="Allow agent to read/write workspace files",

--- a/tests/test_deep_agent_payload_interaction.py
+++ b/tests/test_deep_agent_payload_interaction.py
@@ -1,0 +1,30 @@
+"""Contract test for the allow_user_interaction field on DeepAgentPayload.
+
+This field is the cross-repo switch consumed by autobotAI-core (producer) and
+autobotAI-agents (runtime). It must default to True (interactive) and be
+distinct from `autonomous`.
+"""
+
+from autobotAI_integrations.deep_agent_schema import DeepAgentPayload
+
+
+def _payload(**overrides):
+    base = dict(job_id="j", tasks=[], user_prompt="hi")
+    base.update(overrides)
+    return DeepAgentPayload(**base)
+
+
+def test_defaults_to_interactive():
+    assert _payload().allow_user_interaction is True
+
+
+def test_explicit_false_is_headless():
+    assert _payload(allow_user_interaction=False).allow_user_interaction is False
+
+
+def test_independent_of_autonomous():
+    # The two flags are orthogonal: a headless run can still be autonomous,
+    # and an interactive run can require approve-before-act.
+    p = _payload(autonomous=False, allow_user_interaction=True)
+    assert p.autonomous is False
+    assert p.allow_user_interaction is True


### PR DESCRIPTION
## Summary
Adds `allow_user_interaction: bool = True` to `DeepAgentPayload` — the single cross-repo switch for whether a human is in the loop.

Distinct from the existing `autonomous` flag (which gates approve-before-each-action on `execute`/`write_file`). `allow_user_interaction` controls:
- whether the agent runtime equips the `request_approval` HITL tool, and
- whether the chat thread accepts user messages.

Consumed by **autobotAI-core** (sets it from the bot node) and **autobotAI-agents** (gates the HITL tool on it). Defaults `True` (interactive).

## Part of a 3-repo change
- autobotAI-agents: gate `request_approval` on the flag.
- autobotAI-core: default True on DeepAgentNode, Optimus sets it per trigger, payload carries it, send_message guard, ECS shutdown on non-interactive completion.

Re-pin this package's tag in core + agents before deploy.

## Tests
`tests/test_deep_agent_payload_interaction.py` — default True, explicit False, orthogonal to `autonomous`. (3 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control human-in-the-loop mode for runs, enabling user interactions and approval requests when active, or running headless when disabled.

* **Tests**
  * Added comprehensive test coverage for the human-in-the-loop mode setting to ensure proper defaults and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->