### PR TITLE
feat(openrouter): add generate_llm_credentials + expand model catalog

### DIFF
--- a/autobotAI_integrations/integrations/openrouter/__init__.py
+++ b/autobotAI_integrations/integrations/openrouter/__init__.py
@@ -73,6 +73,23 @@ class OpenRouterService(AIBaseService):
                 "meta-llama/llama-3.3-70b-instruct",
                 "mistralai/mistral-large",
                 "deepseek/deepseek-r1",
+                "deepseek/deepseek-v4-flash",
+                "openrouter/owl-alpha",
+                "qwen/qwen3.7-max",
+                "moonshotai/kimi-k2.6",
+                "minimax/minimax-m3",
+                "tencent/hy3-preview",
+                "deepseek/deepseek-v4-pro",
+                "xiaomi/mimo-v2.5",
+                "anthropic/claude-sonnet-4.6",
+                "anthropic/claude-opus-4.7",
+                "anthropic/claude-opus-4.8",
+                "stepfun/step-3.7-flash",
+                "nvidia/nemotron-3-ultra-550b-a55b:free",
+                "google/gemini-3.5-flash",
+                "nvidia/nemotron-3-super-120b-a12b:free",
+                "openai/gpt-oss-120b",
+                "z-ai/glm-5.1",
             ]
             return {
                 "integration_id": self.integration.accountId,
@@ -188,6 +205,17 @@ class OpenRouterService(AIBaseService):
 
     def generate_cli_creds(self) -> CLICreds:
         pass
+
+    def generate_llm_credentials(self):
+        # OpenRouter is an OpenAI-compatible gateway, so the deep-agent runtime
+        # talks to it through an OpenAI client pointed at OPENROUTER_BASE_URL.
+        # NOTE: the consuming runtime (agent_core) must map provider="openrouter"
+        # onto that OpenAI-compatible client using base_url for this to work end
+        # to end; returning the creds here is necessary but not sufficient.
+        return {
+            "api_key": self.integration.api_key,
+            "base_url": OPENROUTER_BASE_URL,
+        }
 
     def get_pydantic_agent(
         self, model: str, tools, system_prompt: str, options: dict = {}

--- a/tests/test_integrations/test_openrouter.py
+++ b/tests/test_integrations/test_openrouter.py
@@ -57,6 +57,14 @@ class TestClassOpenRouter:
         # Multi-provider routing — names should be namespaced.
         assert any("/" in m for m in details["models"])
 
+    def test_generate_llm_credentials(self, sample_integration_dict):
+        # Deep-agent payload builder calls this to populate LLMConfig; OpenRouter
+        # is an OpenAI-compatible gateway so it must return api_key + base_url.
+        integration = sample_integration_dict("openrouter", {"api_key": "sk-or-test"})
+        service = integration_service_factory.get_service(None, integration)
+        creds = service.generate_llm_credentials()
+        assert creds == {"api_key": "sk-or-test", "base_url": OPENROUTER_BASE_URL}
+
     def test_ai_prompt_python_template(self):
         template = OpenRouterService.ai_prompt_python_template()
         assert template["integration_type"] == "openrouter"


### PR DESCRIPTION
## Why
Optimus deep-agent threads using the **OpenRouter** LLM provider failed before reaching the model with *"LLM not configured — open ⚙ Settings…"*. Root cause: the payload builder (`optimus_payload_service._get_llm_config`) resolves provider credentials via `integration_service.generate_llm_credentials()`. OpenRouter never implemented it, so the base `AIBaseService.generate_llm_credentials()` raised `NotImplementedError`, which was swallowed → `llm_config=None`. The model name (`openai/gpt-5-mini`, etc.) was irrelevant.

## What
- Implement `OpenRouterService.generate_llm_credentials()` → `{api_key, base_url}` (OpenRouter is an OpenAI-compatible gateway).
- Expand the OpenRouter model picker with the newly requested models (deepseek-v4-flash/pro, owl-alpha, qwen3.7-max, kimi-k2.6, minimax-m3, hy3-preview, mimo-v2.5, claude-sonnet-4.6/opus-4.7/opus-4.8, step-3.7-flash, nemotron-3 ultra/super :free, gemini-3.5-flash, gpt-oss-120b, glm-5.1).
- Add `test_generate_llm_credentials` to the OpenRouter suite.

## Companion PRs (must ship together)
- **autobotAI-agents**: `agent_core` maps `provider="openrouter"` → `ChatOpenAI(base_url=…)`.
- **autobotAI-core**: improved `_get_llm_config` error logging + integrations pin bump.

## Release note
After merge to `test`, cut tag **`v2.2.6-test-p4`** here — the core PR pins to it.

## Tests
`pytest tests/test_integrations/test_openrouter.py` → 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available model catalog for OpenRouter integration, including additional DeepSeek, Qwen, Kimi, Nvidia, and OpenAI OSS model options.
  * Enhanced OpenRouter integration with improved OpenAI-compatible connection configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->