### PR TITLE
feat(deep-agent): goal-driven run mode + resolution taxonomy

### DIFF
--- a/autobotAI_integrations/deep_agent_schema.py
+++ b/autobotAI_integrations/deep_agent_schema.py
@@ -197,6 +197,39 @@ class FileConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class RunMode(str, Enum):
+    """How a deep-agent run decides when it is finished.
+
+    - ``interactive`` (default): the run never self-terminates on its own. It
+      ends only when the user ends the session or the compute deadline hits.
+      This is the classic Optimus behaviour — unchanged.
+    - ``goal_driven``: the run pursues a fixed ``goal`` and exits the moment the
+      agent calls ``complete_goal`` (or a ``hard_deadline`` backstop fires). The
+      compute lease (``session_timeout_hours``) only parks-and-resumes such a
+      run; it never finalizes it.
+    """
+
+    INTERACTIVE = "interactive"
+    GOAL_DRIVEN = "goal_driven"
+
+
+class GoalResolution(str, Enum):
+    """Structured outcome the agent reports via ``complete_goal``.
+
+    Richer than completed/failed so the risk register can distinguish how a
+    goal ended (fixed vs. accepted-as-risk vs. blocked vs. no action needed).
+    """
+
+    RESOLVED_FIXED = "resolved_fixed"
+    ACCEPTED_RISK = "accepted_risk"
+    WONT_FIX = "wont_fix"
+    NO_ACTION = "no_action"
+    BLOCKED_AUTO = "blocked_auto"
+    BLOCKED_APPROVED = "blocked_approved"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+
+
 class DeepAgentPayload(Payload):
     """
     Extends the standard autobotAI ``Payload`` with deep-agent-specific fields.
@@ -259,6 +292,38 @@ class DeepAgentPayload(Payload):
     shell_access_enabled: bool = Field(
         False,
         description="Allow agent to execute shell commands",
+    )
+
+    # --- Goal-driven termination -------------------------------------------
+    # Orthogonal to `autonomous` / `allow_user_interaction`: those gate HOW the
+    # agent acts; these decide WHEN the run ends.
+    run_mode: RunMode = Field(
+        RunMode.INTERACTIVE,
+        description=(
+            "interactive (default, classic Optimus) or goal_driven (exits when "
+            "the agent calls complete_goal; lease expiry parks-and-resumes)."
+        ),
+    )
+    goal: Optional[str] = Field(
+        None,
+        description="The objective the goal_driven run pursues (ignored when interactive).",
+    )
+    exit_criteria: Optional[str] = Field(
+        None,
+        description=(
+            "Explicit, checkable condition for calling complete_goal — what "
+            "'done' looks like for this goal (ignored when interactive)."
+        ),
+    )
+    hard_deadline_hours: Optional[int] = Field(
+        None,
+        ge=1,
+        description=(
+            "Absolute backstop, in hours from run start, for a goal_driven run. "
+            "If the agent never calls complete_goal by then, core finalizes the "
+            "run as timed_out. Distinct from session_timeout_hours (the compute "
+            "lease, which only parks-and-resumes). None → a finite default cap."
+        ),
     )
 
     # --- Memory spaces -----------------------------------------------------
@@ -384,4 +449,12 @@ class DeepAgentResponse(BaseModel):
             "Present only when status=AWAITING_INPUT. Contains the raw HITLRequest "
             "from the agent interrupt: {action_requests: [...], review_configs: [...]}"
         ),
+    )
+    goal_complete: bool = Field(
+        False,
+        description="True when a goal_driven run called complete_goal this turn.",
+    )
+    resolution: Optional[GoalResolution] = Field(
+        None,
+        description="The structured outcome from complete_goal (goal_driven runs only).",
     )

--- a/autobotAI_integrations/deep_agent_schema.py
+++ b/autobotAI_integrations/deep_agent_schema.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from autobotAI_integrations.payload_schema import Payload, PayloadCommonContext
 
@@ -325,6 +325,15 @@ class DeepAgentPayload(Payload):
             "lease, which only parks-and-resumes). None → a finite default cap."
         ),
     )
+
+    @model_validator(mode="after")
+    def _require_goal_when_goal_driven(self) -> "DeepAgentPayload":
+        # A goal_driven run is meaningless without a goal — mirror the same
+        # invariant enforced on core's OptimusConfigBaseSchema so the contract
+        # can't be violated from either side.
+        if self.run_mode == RunMode.GOAL_DRIVEN and not (self.goal and self.goal.strip()):
+            raise ValueError("run_mode=goal_driven requires a non-empty goal")
+        return self
 
     # --- Memory spaces -----------------------------------------------------
     memory_spaces: List[MemorySpaceConfig] = Field(


### PR DESCRIPTION
Part 1/3 of goal-driven deep agents (merge first — schema contract).

## What
Adds the deep-agent goal-driven termination contract to the shared schema:
- `RunMode` (`interactive` | `goal_driven`) and `GoalResolution` enums.
- `DeepAgentPayload`: `goal`, `exit_criteria`, `hard_deadline_hours`, `run_mode`.
- `DeepAgentResponse`: `goal_complete`, `resolution`.

Default `interactive` — existing deep agents are unchanged.

## Why
A goal-driven deep agent exits when it calls `complete_goal` (the agents-side
tool), instead of running open-ended like Optimus. This is the schema contract
both autobotAI-agents and autobotAI-core depend on.

## Order
Merge **before** the autobotAI-agents and autobotAI-core PRs (they consume
these fields); the package then needs a version bump + repin in those repos.

## Tests
Schema import + payload/round-trip validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added goal-driven execution mode for agents with customizable objectives and success criteria
  * Implemented hard deadline support with automatic timeout handling
  * Added goal completion and resolution tracking with structured outcome states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->