### PR TITLE
refactor(deep-agent): drop exit_criteria (goal defines done-condition)

### DIFF
--- a/autobotAI_integrations/deep_agent_schema.py
+++ b/autobotAI_integrations/deep_agent_schema.py
@@ -306,13 +306,10 @@ class DeepAgentPayload(Payload):
     )
     goal: Optional[str] = Field(
         None,
-        description="The objective the goal_driven run pursues (ignored when interactive).",
-    )
-    exit_criteria: Optional[str] = Field(
-        None,
         description=(
-            "Explicit, checkable condition for calling complete_goal — what "
-            "'done' looks like for this goal (ignored when interactive)."
+            "The objective the goal_driven run pursues — must state both what to "
+            "achieve AND its done-condition (when to call complete_goal). Ignored "
+            "when interactive."
         ),
     )
     hard_deadline_hours: Optional[int] = Field(


### PR DESCRIPTION
Part 1/4. The goal already encodes its done-condition; a separate exit_criteria was redundant and could diverge. Removes the field from DeepAgentPayload. Agents/core/FE PRs follow; repin integrations after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated goal field specifications to clarify requirements for goal-driven runs and behavior in interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->