### PR TITLE
feat(autobotai): short-circuit _test_integration for the self sentinel

### DIFF
--- a/autobotAI_integrations/integrations/autobotai/__init__.py
+++ b/autobotAI_integrations/integrations/autobotai/__init__.py
@@ -25,6 +25,11 @@ class AutobotAIService(BaseService):
         super().__init__(ctx, integration)
 
     def _test_integration(self):
+        # The default "self" integration points at the same autobotAI instance;
+        # its base_url/api_key are sentinels resolved at request time by core
+        # (shared.services.autobotai_self). Nothing to validate here.
+        if self.integration.base_url == "self" or self.integration.api_key == "self":
+            return {"success": True}
         try:
             user_endpoint =  f"{self.integration.base_url}/integrations"
             response = requests.get(


### PR DESCRIPTION
## Why
Companion to autobotAI-core #1666. The default **self** autobotai integration now stores `base_url`/`api_key` = `"self"` and is resolved at request time by core (`shared.services.autobotai_self`). Running the integration "Test" against it as an external instance would fail.

## What
`_test_integration` returns success when `base_url`/`api_key` is the `"self"` sentinel — the self instance is always valid. External instances (real URL + key via the form) are unchanged.

## Notes
Independent of the core PR — core resolves the sentinels before constructing the service, so MCP usage works regardless. This only affects the explicit Test action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration validation efficiency by optimizing the test flow for specific configuration scenarios, resulting in faster validation times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->